### PR TITLE
chore: remove user backend code

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -32,12 +32,10 @@ Preferred communication style: Simple, everyday language.
 
 ## Database Schema
 - **Questions Table**: Stores questions with mood, occasion, and multilingual translations as JSONB
-- **Users Table**: Basic user authentication structure with username/password
 - **Shared Types**: TypeScript types generated from Drizzle schema definitions
 
 ## External Dependencies
 - **Database Provider**: Neon Database (PostgreSQL) via @neondatabase/serverless
-- **Session Management**: connect-pg-simple for PostgreSQL session storage
 - **UI Components**: Comprehensive Radix UI component collection for accessible primitives
 - **Validation**: Zod for schema validation and type inference
 - **Date Handling**: date-fns for date manipulation utilities

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,44 +1,21 @@
-import { type User, type InsertUser, type Question, type InsertQuestion } from "@shared/schema";
-import { randomUUID } from "crypto";
+import { type Question } from "@shared/schema";
 import { readFileSync } from "fs";
 
 export interface IStorage {
-  getUser(id: string): Promise<User | undefined>;
-  getUserByUsername(username: string): Promise<User | undefined>;
-  createUser(user: InsertUser): Promise<User>;
   getQuestions(filters?: { mood?: string; occasion?: string }): Promise<Question[]>;
   getRandomQuestion(filters?: { mood?: string; occasion?: string }): Promise<Question | undefined>;
 }
 
 export class MemStorage implements IStorage {
-  private users: Map<string, User>;
   private questions: Question[];
 
   constructor() {
-    this.users = new Map();
     this.questions = this.initializeQuestions();
   }
 
   private initializeQuestions(): Question[] {
     const data = readFileSync(new URL("./questions.json", import.meta.url), "utf-8");
     return JSON.parse(data) as Question[];
-  }
-
-  async getUser(id: string): Promise<User | undefined> {
-    return this.users.get(id);
-  }
-
-  async getUserByUsername(username: string): Promise<User | undefined> {
-    return Array.from(this.users.values()).find(
-      (user) => user.username === username,
-    );
-  }
-
-  async createUser(insertUser: InsertUser): Promise<User> {
-    const id = randomUUID();
-    const user: User = { ...insertUser, id };
-    this.users.set(id, user);
-    return user;
   }
 
   async getQuestions(filters?: { mood?: string; occasion?: string }): Promise<Question[]> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -19,20 +19,6 @@ export const insertQuestionSchema = createInsertSchema(questions).pick({
 export type InsertQuestion = z.infer<typeof insertQuestionSchema>;
 export type Question = typeof questions.$inferSelect;
 
-export const users = pgTable("users", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  username: text("username").notNull().unique(),
-  password: text("password").notNull(),
-});
-
-export const insertUserSchema = createInsertSchema(users).pick({
-  username: true,
-  password: true,
-});
-
-export type InsertUser = z.infer<typeof insertUserSchema>;
-export type User = typeof users.$inferSelect;
-
 // Language and filter types
 export const LANGUAGES = [
   { code: 'en', name: 'English' },


### PR DESCRIPTION
## Summary
- drop all user-related storage and schema definitions since app has no users
- clean up documentation to reflect question-only data model

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b44e67fd648323908cff36d482e852