### PR TITLE
feat: default language from browser settings

### DIFF
--- a/client/src/lib/questions.ts
+++ b/client/src/lib/questions.ts
@@ -40,6 +40,16 @@ export const getLanguagePreference = (): LanguageCode => {
     if (saved && LANGUAGES.find(l => l.code === saved)) {
       return saved;
     }
+    if (typeof navigator !== 'undefined') {
+      // Use the browser's language settings (Accept-Language) to find a match
+      const browserLanguages = navigator.languages ?? [navigator.language];
+      for (const lang of browserLanguages) {
+        const code = lang.split('-')[0];
+        if (LANGUAGES.some(l => l.code === code)) {
+          return code as LanguageCode;
+        }
+      }
+    }
   } catch (error) {
     console.warn('Failed to load language preference:', error);
   }


### PR DESCRIPTION
## Summary
- detect preferred language using browser's Accept-Language header
- fall back to English if no supported language is found
- continue persisting language choices in localStorage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b44fa8b3b483239bbddaf139a236cd